### PR TITLE
feat: layouts saved to settings; preview cut lines now rendered optio…

### DIFF
--- a/flutter/lib/core/page_preview/card_area.dart
+++ b/flutter/lib/core/page_preview/card_area.dart
@@ -235,7 +235,7 @@ class _CardAreaState extends State<CardArea> {
                             guideVertical: widget.guideVertical,
                             color: Colors.red,
                             // color: widget.previewCutLine ? Colors.red : const Color.fromARGB(60, 255, 255, 255),
-                            strokeWidth: 1.0,
+                            strokeWidth: 2.0,
                             cornerLength: 10,
                           ),
                           child: imageFileWidget

--- a/flutter/lib/core/page_preview/card_area.dart
+++ b/flutter/lib/core/page_preview/card_area.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 
 import 'package:homeprint_o_tool/core/json.dart';
 import 'package:homeprint_o_tool/core/card_face.dart';
+import 'package:homeprint_o_tool/core/page_preview/corner_paint.dart';
 import 'package:homeprint_o_tool/core/project_settings.dart';
 import 'package:homeprint_o_tool/page/layout/back_arrangement.dart';
 import 'package:homeprint_o_tool/page/layout/layout_data.dart';
@@ -228,7 +229,17 @@ class _CardAreaState extends State<CardArea> {
                     child: SizedBox(
                       height: double.infinity,
                       width: double.infinity,
-                      child: imageFileWidget,
+                      child: CustomPaint(
+                          foregroundPainter: CornerPainter(
+                            guideHorizontal: widget.guideHorizontal,
+                            guideVertical: widget.guideVertical,
+                            color: Colors.red,
+                            // color: widget.previewCutLine ? Colors.red : const Color.fromARGB(60, 255, 255, 255),
+                            strokeWidth: 1.0,
+                            cornerLength: 10,
+                          ),
+                          child: imageFileWidget
+                      ),
                     ),
                   );
                 },

--- a/flutter/lib/core/page_preview/corner_paint.dart
+++ b/flutter/lib/core/page_preview/corner_paint.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+
+class CornerPainter extends CustomPainter {
+  CornerPainter({required this.guideHorizontal, required this.guideVertical, this.color = Colors.red, this.strokeWidth = 1.0, this.cornerLength = 10});
+
+  // Fraction of width taken by the inner area (0..1)
+  final double guideHorizontal;
+  // Fraction of height taken by the inner area (0..1)
+  final double guideVertical;
+  final Color color;
+  final double strokeWidth;
+  final double cornerLength;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final double sh = size.height;
+    final double sw = size.width;
+
+    // Compute inner rectangle based on guides (centered band in both directions)
+    final double innerW = (guideHorizontal.clamp(0.0, 1.0)) * sw;
+    final double innerH = (guideVertical.clamp(0.0, 1.0)) * sh;
+
+    if (innerW <= 0 || innerH <= 0) {
+      return; // nothing to draw
+    }
+
+    final double left = (sw - innerW) / 2.0;
+    final double top = (sh - innerH) / 2.0;
+    final double right = left + innerW;
+    final double bottom = top + innerH;
+
+    final Paint paint = Paint()
+      ..color = color
+      ..strokeWidth = strokeWidth
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.butt;
+
+    // Clamp corner length to reasonable size based on inner dimensions
+    final double maxCl = (innerW < innerH ? innerW : innerH) / 4.0;
+    final double cl = cornerLength.clamp(0.0, maxCl);
+
+    final Path path = Path()
+      // Top Left
+      ..moveTo(left, top-cl)
+      ..lineTo(left, top + cl)
+      ..moveTo(left-cl, top)
+      ..lineTo(left + cl, top)
+      // Top Right
+      ..moveTo(right+cl, top)
+      ..lineTo(right - cl, top)
+      ..moveTo(right, top-cl)
+      ..lineTo(right, top + cl)
+      // Bottom Left
+      ..moveTo(left-cl, bottom)
+      ..lineTo(left + cl, bottom)
+      ..moveTo(left, bottom+cl)
+      ..lineTo(left, bottom - cl)
+      // Bottom Right
+      ..moveTo(right+cl, bottom)
+      ..lineTo(right - cl, bottom)
+      ..moveTo(right, bottom+cl)
+      ..lineTo(right, bottom - cl);
+
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(CornerPainter oldDelegate) =>
+      oldDelegate.guideHorizontal != guideHorizontal ||
+      oldDelegate.guideVertical != guideVertical ||
+      oldDelegate.color != color ||
+      oldDelegate.strokeWidth != strokeWidth ||
+      oldDelegate.cornerLength != cornerLength;
+
+  @override
+  bool shouldRebuildSemantics(CornerPainter oldDelegate) => false;
+}

--- a/flutter/lib/core/page_preview/render.dart
+++ b/flutter/lib/core/page_preview/render.dart
@@ -30,6 +30,7 @@ class ExportSettings {
   final Rotation backRotation;
   final bool frontSideOnly;
   final int pixelPerInch;
+  final bool previewCutLine;
 
   ExportSettings({
     required this.prefix,
@@ -40,6 +41,7 @@ class ExportSettings {
     required this.backRotation,
     required this.frontSideOnly,
     required this.pixelPerInch,
+    required this.previewCutLine,
   });
 }
 
@@ -226,7 +228,7 @@ Future renderRender(
           layoutData: layoutData,
           cards: cards.front,
           layout: false,
-          previewCutLine: false,
+          previewCutLine: settings.previewCutLine,
           baseDirectory: baseDirectory,
           projectSettings: projectSettings,
           hideInnerCutLine: true,
@@ -254,6 +256,7 @@ Future renderRender(
             settings.backSuffix,
             i,
             settings.frontRotation,
+            settings.previewCutLine,
           );
         } catch (e) {
           print('Error rendering front side of page ${i + 1}: $e');
@@ -279,7 +282,7 @@ Future renderRender(
           layoutData: layoutData,
           cards: cards.back,
           layout: false,
-          previewCutLine: false,
+          previewCutLine: settings.previewCutLine,
           baseDirectory: baseDirectory,
           projectSettings: projectSettings,
           hideInnerCutLine: true,
@@ -307,6 +310,7 @@ Future renderRender(
             settings.backSuffix,
             i,
             settings.backRotation,
+            settings.previewCutLine,
           );
         } catch (e) {
           print('Error rendering back side of page ${i + 1}: $e');
@@ -412,12 +416,13 @@ Future<void> renderOneSide(
     String frontSuffix,
     String backSuffix,
     int pageNumber,
-    Rotation rotation) async {
+    Rotation rotation,
+    bool previewCutLine) async {
   PagePreview toRender = PagePreview(
     layoutData: layoutData,
     cards: cardsOnePage,
     layout: false,
-    previewCutLine: false,
+    previewCutLine: previewCutLine,
     baseDirectory: baseDirectory,
     projectSettings: projectSettings,
     hideInnerCutLine: true,
@@ -485,6 +490,7 @@ Future<ExportSettings?> openPreExportDialog(
   Rotation tempFrontRotation = Rotation.none;
   Rotation tempBackRotation = Rotation.none;
   bool tempFrontSideOnly = false;
+  bool tempPreviewCutLine = false;
   int tempPixelPerInch = 300; // Default PPI value
 
   return await showDialog<ExportSettings>(
@@ -507,6 +513,17 @@ Future<ExportSettings?> openPreExportDialog(
                     onChanged: (value) {
                       setState(() {
                         tempFrontSideOnly = value ?? false;
+                      });
+                    },
+                  ),
+                  CheckboxListTile(
+                    title: Text('Show Cut Lines in Export'),
+                    value: tempPreviewCutLine,
+                    controlAffinity: ListTileControlAffinity.leading,
+                    contentPadding: EdgeInsets.zero,
+                    onChanged: (value) {
+                      setState(() {
+                        tempPreviewCutLine = value ?? false;
                       });
                     },
                   ),
@@ -665,6 +682,7 @@ Future<ExportSettings?> openPreExportDialog(
                       backRotation: tempBackRotation,
                       frontSideOnly: tempFrontSideOnly,
                       pixelPerInch: tempPixelPerInch,
+                      previewCutLine: tempPreviewCutLine,
                     ),
                   ); // Confirm
                 },

--- a/flutter/lib/core/project_settings.dart
+++ b/flutter/lib/core/project_settings.dart
@@ -1,3 +1,4 @@
+import 'package:homeprint_o_tool/page/layout/back_arrangement.dart';
 import 'package:homeprint_o_tool/page/layout/layout_data.dart';
 import 'package:flutter/material.dart';
 
@@ -10,8 +11,26 @@ class ProjectSettings extends ChangeNotifier {
   late double defaultContentExpand;
   late Rotation defaultRotation;
 
+  // New: store layout data inside project settings
+  late LayoutData layoutSettings;
+
   ProjectSettings(this.cardSize, this.defaultContentCenterOffset,
-      this.defaultContentExpand, this.defaultRotation);
+      this.defaultContentExpand, this.defaultRotation,
+      {LayoutData? layoutSettings}) {
+    // If not provided, initialize with a basic default to maintain backward compatibility
+    this.layoutSettings = layoutSettings ??
+        LayoutData(
+          paperSize: SizePhysical(21, 29.7, PhysicalSizeType.centimeter),
+          marginSize: SizePhysical(0.25, 0.25, PhysicalSizeType.inch),
+          edgeCutGuideSize: SizePhysical(0.5, 0.5, PhysicalSizeType.centimeter),
+          backArrangement: BackArrangement.invertedRow,
+          skips: [],
+          removeOneColumn: false,
+          removeOneRow: false,
+          frontPostRotation: Rotation.none,
+          backPostRotation: Rotation.none,
+        );
+  }
 
   ProjectSettings.fromJson(Map<String, dynamic> json) {
     cardSize = SizePhysical.fromJson(json['cardSize']);
@@ -34,6 +53,23 @@ class ProjectSettings extends ChangeNotifier {
     } else {
       defaultRotation = Rotation.none;
     }
+
+    final layoutSettingsJson = json['layoutSettings'];
+    if (layoutSettingsJson != null) {
+      layoutSettings = LayoutData.fromJson(layoutSettingsJson);
+    } else {
+      layoutSettings = LayoutData(
+        paperSize: SizePhysical(21, 29.7, PhysicalSizeType.centimeter),
+        marginSize: SizePhysical(0.25, 0.25, PhysicalSizeType.inch),
+        edgeCutGuideSize: SizePhysical(0.5, 0.5, PhysicalSizeType.centimeter),
+        backArrangement: BackArrangement.invertedRow,
+        skips: [],
+        removeOneColumn: false,
+        removeOneRow: false,
+        frontPostRotation: Rotation.none,
+        backPostRotation: Rotation.none,
+      );
+    }
   }
 
   Map<String, dynamic> toJson() {
@@ -42,6 +78,7 @@ class ProjectSettings extends ChangeNotifier {
       'defaultContentCenterOffset': alignmentToJson(defaultContentCenterOffset),
       'defaultContentExpand': defaultContentExpand,
       'defaultRotation': defaultRotation.name,
+      'layoutSettings': layoutSettings.toJson(),
     };
   }
 }

--- a/flutter/lib/core/save_file.dart
+++ b/flutter/lib/core/save_file.dart
@@ -56,7 +56,8 @@ class SaveFile {
   /// Returns file name and directory of the file.
   Future<({String fileName, String baseDirectory})> saveToFile(
       String path) async {
-    var file = File(path);
+    final filePath = path.endsWith('.json') ? path : '$path.json';
+    var file = File(filePath);
     final jsonString = jsonEncode(toJson());
     await file.writeAsString(jsonString);
     final baseDirectory = p.dirname(path);

--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -67,7 +67,8 @@ ProjectSettings getDefaultProjectSettings() => ProjectSettings(
     SizePhysical(6.3, 8.8, PhysicalSizeType.centimeter),
     Alignment.center,
     1.0,
-    Rotation.none);
+    Rotation.none,
+    layoutSettings: getDefaultLayoutData());
 
 // Return a fresh copy of default cards each time to avoid shared references
 DefinedCards getDefaultDefinedCards() => [CardGroup([], "Default Group")];
@@ -298,6 +299,8 @@ class _MyHomePageState extends State<MyHomePage> {
         // Append .json if not already.
         final filePathJson =
             !filePath.path.endsWith(".json") ? "$filePath.json" : filePath.path;
+        // Ensure layout settings are saved inside project settings
+        _projectSettings.layoutSettings = _layoutData;
         final saveFile =
             SaveFile(_projectSettings, _linkedCardFaces, _definedCards);
         final saveResult = await saveFile.saveToFile(filePathJson);
@@ -316,6 +319,8 @@ class _MyHomePageState extends State<MyHomePage> {
           _includes = [];
           _skipIncludes = [];
           _layoutData = getDefaultLayoutData();
+          // Keep project settings in sync with UI layout data
+          _projectSettings.layoutSettings = _layoutData;
           // On new, go to project settings.
           _selectedIndex = 0;
         });
@@ -333,6 +338,8 @@ class _MyHomePageState extends State<MyHomePage> {
             _previousFileName = loadResult.fileName;
             _includes = [];
             _skipIncludes = [];
+            // Sync UI layout data from loaded project settings
+            _layoutData = _projectSettings.layoutSettings;
             // On load, go to cards tab.
             _selectedIndex = 2;
           });

--- a/flutter/lib/page/layout/layout_data.dart
+++ b/flutter/lib/page/layout/layout_data.dart
@@ -37,6 +37,39 @@ class LayoutData {
     required this.frontPostRotation,
     required this.backPostRotation,
   });
+
+  factory LayoutData.fromJson(Map<String, dynamic> json) {
+    return LayoutData(
+      paperSize: SizePhysical.fromJson(json['paperSize']),
+      marginSize: SizePhysical.fromJson(json['marginSize']),
+      edgeCutGuideSize: SizePhysical.fromJson(json['edgeCutGuideSize']),
+      backArrangement: BackArrangement.values
+          .byName(json['backArrangement'] ?? 'invertedRow'),
+      skips: (json['skips'] as List<dynamic>? ?? [])
+          .map((e) => e is int ? e : int.tryParse(e.toString()) ?? 0)
+          .toList(),
+      removeOneRow: json['removeOneRow'] ?? false,
+      removeOneColumn: json['removeOneColumn'] ?? false,
+      frontPostRotation:
+          Rotation.values.byName(json['frontPostRotation'] ?? 'none'),
+      backPostRotation:
+          Rotation.values.byName(json['backPostRotation'] ?? 'none'),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'paperSize': paperSize.toJson(),
+      'marginSize': marginSize.toJson(),
+      'edgeCutGuideSize': edgeCutGuideSize.toJson(),
+      'backArrangement': backArrangement.name,
+      'skips': skips,
+      'removeOneRow': removeOneRow,
+      'removeOneColumn': removeOneColumn,
+      'frontPostRotation': frontPostRotation.name,
+      'backPostRotation': backPostRotation.name,
+    };
+  }
 }
 
 enum PhysicalSizeType {

--- a/flutter/lib/page/project/project_page.dart
+++ b/flutter/lib/page/project/project_page.dart
@@ -28,6 +28,7 @@ class ProjectPage extends StatelessWidget {
       projectSettings.defaultContentCenterOffset,
       projectSettings.defaultContentExpand,
       projectSettings.defaultRotation,
+      layoutSettings: projectSettings.layoutSettings,
     );
     onProjectSettingsChanged(updatedSettings);
   }
@@ -38,6 +39,7 @@ class ProjectPage extends StatelessWidget {
       projectSettings.defaultContentCenterOffset,
       value,
       projectSettings.defaultRotation,
+      layoutSettings: projectSettings.layoutSettings,
     );
     onProjectSettingsChanged(updatedSettings);
   }
@@ -48,6 +50,7 @@ class ProjectPage extends StatelessWidget {
       projectSettings.defaultContentCenterOffset,
       projectSettings.defaultContentExpand,
       value,
+      layoutSettings: projectSettings.layoutSettings,
     );
     onProjectSettingsChanged(updatedSettings);
   }

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   cli_util:
     dependency: transitive
     description:
@@ -117,26 +117,26 @@ packages:
     dependency: "direct main"
     description:
       name: file_selector
-      sha256: "5019692b593455127794d5718304ff1ae15447dea286cdda9f0db2a796a1b828"
+      sha256: "5f1d15a7f17115038f433d1b0ea57513cc9e29a9d5338d166cb0bef3fa90a7a0"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   file_selector_android:
     dependency: transitive
     description:
       name: file_selector_android
-      sha256: "6bba3d590ee9462758879741abc132a19133600dd31832f55627442f1ebd7b54"
+      sha256: "2db9a2d05f66b49a3b45c4a7c2f040dd5fcd457ca30f39df7cdcf80b8cd7f2d4"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1+14"
+    version: "0.5.2+1"
   file_selector_ios:
     dependency: transitive
     description:
       name: file_selector_ios
-      sha256: "94b98ad950b8d40d96fee8fa88640c2e4bd8afcdd4817993bd04e20310f45420"
+      sha256: fc3c3fc567cd9bcae784dfeb98d37c46a8ded9e8757d37ea67e975c399bc14e0
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.3+1"
+    version: "0.5.3+3"
   file_selector_linux:
     dependency: transitive
     description:
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: file_selector_macos
-      sha256: "271ab9986df0c135d45c3cdb6bd0faa5db6f4976d3e4b437cf7d0f258d941bfc"
+      sha256: "88707a3bec4b988aaed3b4df5d7441ee4e987f20b286cddca5d6a8270cab23f2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.4+2"
+    version: "0.9.4+5"
   file_selector_platform_interface:
     dependency: transitive
     description:
@@ -194,10 +194,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_launcher_icons
-      sha256: bfa04787c85d80ecb3f8777bde5fc10c3de809240c48fa061a2c2bf15ea5211c
+      sha256: "10f13781741a2e3972126fae08393d3c4e01fa4cd7473326b94b72cf594195e7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.3"
+    version: "0.14.4"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -220,10 +220,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
+      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   http_parser:
     dependency: transitive
     description:
@@ -252,10 +252,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.1"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -316,18 +316,18 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "7976bfe4c583170d6cdc7077e3237560b364149fcd268b5f53d95a991963b191"
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.0"
+    version: "8.3.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: "6c935fb612dff8e3cc9632c2b301720c77450a126114126ffaafe28d2e87956c"
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.1"
   path:
     dependency: "direct main"
     description:
@@ -340,10 +340,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "07c8f0b1913bcde1ff0d26e57ace2f3012ccbf2b204e070290dad3bb22797646"
+      sha256: "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "7.0.1"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -356,18 +356,18 @@ packages:
     dependency: transitive
     description:
       name: posix
-      sha256: f0d7856b6ca1887cfa6d1d394056a296ae33489db914e365e2044fdada449e62
+      sha256: "6323a5b0fa688b6a010df4905a56b00181479e6d10534cecfecede2aa55add61"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "6.0.3"
   provider:
     dependency: "direct main"
     description:
       name: provider
-      sha256: "4abbd070a04e9ddc287673bf5a030c7ca8b685ff70218720abab8b092f53dd84"
+      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.5"
+    version: "6.1.5+1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -425,10 +425,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   typed_data:
     dependency: transitive
     description:
@@ -441,26 +441,26 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher
-      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.3.2"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "8582d7f6fe14d2652b4c45c9b6c14c0b678c2af2d083a11b604caeba51930d79"
+      sha256: "5c8b6c2d89a78f5a1cca70a73d9d5f86c701b36b42f9c9dac7bad592113c28e9"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.16"
+    version: "6.3.24"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "7f2022359d4c099eea7df3fdf739f7d3d3b9faf3166fb1dd390775176e0b76cb"
+      sha256: "6b63f1441e4f653ae799166a72b50b1767321ecc263a57aadf825a7a2a5477d9"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.3"
+    version: "6.3.5"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -473,10 +473,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
+      sha256: "8262208506252a3ed4ff5c0dc1e973d2c0e0ef337d0a074d35634da5d44397c9"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.2"
+    version: "3.2.4"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -513,18 +513,18 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "15.0.2"
   web:
     dependency: transitive
     description:
@@ -537,26 +537,26 @@ packages:
     dependency: "direct main"
     description:
       name: widgets_to_image
-      sha256: "9a251b95d3a9f10d72420dde9b7e3b0da5eddd47fb19cad066bc68c60b0d1dfb"
+      sha256: "4e5b7e88bf62c06a91762a9a713096f095361e4c8e81fdd3875cf19cdad73d3e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "2.0.1"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: "329edf97fdd893e0f1e3b9e88d6a0e627128cc17cc316a8d67fda8f1451178ba"
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
       url: "https://pub.dev"
     source: hosted
-    version: "5.13.0"
+    version: "5.15.0"
   xml:
     dependency: transitive
     description:
       name: xml
-      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:
@@ -566,5 +566,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.7.0 <4.0.0"
-  flutter: ">=3.27.0"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"


### PR DESCRIPTION
New features:
- Added in Preview Cut Line to be rendered as part of the final rendering (I prefer to keep it to help with cutting)
- Added in a check to ensure the project file saving always includes .json (saving without it on windows would leave it as a plain file at times with no extension)
- Layout settings now saved in project settings json as well (Kept having to reset the layout settings every reboot)



Screenshots

New checkbox:
<img width="663" height="835" alt="image" src="https://github.com/user-attachments/assets/c087fd3a-0eda-4ead-9a4d-9affe170bdd3" />

New lines:
<img width="652" height="1186" alt="image" src="https://github.com/user-attachments/assets/5fae0ad1-9b52-4d52-800e-0612a8cf1fdf" />

New JSON Output:

```
{
...
    "defaultContentCenterOffset": {
      "x": 0.0,
      "y": 0.0
    },
    "defaultContentExpand": 0.9907578558225508,
    "defaultRotation": "none",
    "layoutSettings": {
      "paperSize": {
        "width": 8.5,
        "height": 11.0,
        "unit": "in"
      },
      "marginSize": {
        "width": 0.12,
        "height": 0.12,
        "unit": "in"
      },
      "edgeCutGuideSize": {
        "width": 0.3,
        "height": 0.25,
        "unit": "cm"
      },
      "backArrangement": "invertedRow",
      "skips": [],
      "removeOneRow": false,
      "removeOneColumn": false,
      "frontPostRotation": "none",
      "backPostRotation": "none"
    }
  },
  "linkedCardFaces": [
...
}
```